### PR TITLE
@import rules without media lists are serialized with an extraneous space before the semicolon

### DIFF
--- a/lib/CSSImportRule.js
+++ b/lib/CSSImportRule.js
@@ -22,7 +22,8 @@ CSSOM.CSSImportRule.prototype = new CSSOM.CSSRule;
 CSSOM.CSSImportRule.prototype.constructor = CSSOM.CSSImportRule;
 CSSOM.CSSImportRule.prototype.type = 3;
 CSSOM.CSSImportRule.prototype.__defineGetter__("cssText", function() {
-	return "@import url("+ this.href +") "+ this.media.mediaText +";"
+	var mediaText = this.media.mediaText;
+	return "@import url(" + this.href + ")" + (mediaText ? " " + mediaText : "") + ";";
 });
 
 CSSOM.CSSImportRule.prototype.__defineSetter__("cssText", function(cssText) {


### PR DESCRIPTION
Test case:

```
require('cssom').parse('@import url(foo.css);').toString();
```

Output:

```
@import url(foo.css) ;
```
