### PR TITLE
Include properties that have been set directly

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -71,6 +71,7 @@ CSSOM.CSSStyleDeclaration.prototype = {
 		}
 		var prevValue = this[name];
 		this[name] = "";
+		this._importants[name] = "";
 
 		// That's what WebKit and Opera do
 		Array.prototype.splice.call(this, index, 1);
@@ -108,18 +109,21 @@ CSSOM.CSSStyleDeclaration.prototype = {
 	},
 
 	// Doesn't work in IE < 9
-	get cssText(){
+	get cssText() {
 		var properties = [];
-		for (var i=0, length=this.length; i < length; ++i) {
-			var name = this[i];
-			var value = this.getPropertyValue(name);
-			var priority = this.getPropertyPriority(name);
-			if (priority) {
-				priority = " !" + priority;
+		for (var name in this) {
+			if (this.hasOwnProperty(name) && !name.match(/^_.*|\d+$|length/)) {
+				var value = this.getPropertyValue(name);
+				if (value !== "") {
+					var priority = this.getPropertyPriority(name);
+					if (priority) {
+						priority = " !" + priority;
+					}
+					properties.push(name + ': ' + value + priority + ';');
+				}
 			}
-			properties[i] = name + ": " + value + priority + ";";
 		}
-		return properties.join(" ")
+		return properties.join(" ");
 	}
 
 };

--- a/test/CSSStyleDeclaration.test.js
+++ b/test/CSSStyleDeclaration.test.js
@@ -32,4 +32,7 @@ test("CSSStyleDeclaration", function(){
 	
 	equal(d.cssText, "color: green;");
 
+	d.color = "papayawhip";
+	d.width = "100%";
+	equal(d.cssText, "color: papayawhip; width: 100%;");
 });


### PR DESCRIPTION
The cssText property now also includes properties that have been set directly rather than via the `setProperty()` method, i.e. `style.color="red"` vs. `style.setProperty("color", "red")`.