### PR TITLE
Reduced the number of gotchas when publishing a new CSSOM package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/lib/index.js
+/node_modules/

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
 			"type": "MIT",
 			"url": "http://creativecommons.org/licenses/MIT/"
 		}
-	]
+	],
+	"scripts": {
+		"prepublish": "jake lib/index.js"
+	}
 }


### PR DESCRIPTION
- Added prepublish hook to make sure `lib/index.js` gets built and included when publishing the package.
- Added `lib/index.js` and `/node_modules/` to `.gitignore`.
