### PR TITLE
IE9 & IE10 support

### DIFF
--- a/lib/CSSDocumentRule.js
+++ b/lib/CSSDocumentRule.js
@@ -23,12 +23,14 @@ CSSOM.CSSDocumentRule.prototype.type = 10;
 //CSSOM.CSSDocumentRule.prototype.insertRule = CSSStyleSheet.prototype.insertRule;
 //CSSOM.CSSDocumentRule.prototype.deleteRule = CSSStyleSheet.prototype.deleteRule;
 
-CSSOM.CSSDocumentRule.prototype.__defineGetter__("cssText", function() {
+Object.defineProperty(CSSOM.CSSDocumentRule.prototype, "cssText", {
+  get: function() {
     var cssTexts = [];
     for (var i=0, length=this.cssRules.length; i < length; i++) {
         cssTexts.push(this.cssRules[i].cssText);
     }
     return "@-moz-document " + this.matcher.matcherText + " {" + cssTexts.join("") + "}";
+  }
 });
 
 

--- a/lib/CSSFontFaceRule.js
+++ b/lib/CSSFontFaceRule.js
@@ -24,8 +24,10 @@ CSSOM.CSSFontFaceRule.prototype.type = 5;
 //CSSOM.CSSFontFaceRule.prototype.deleteRule = CSSStyleSheet.prototype.deleteRule;
 
 // http://www.opensource.apple.com/source/WebCore/WebCore-955.66.1/css/WebKitCSSFontFaceRule.cpp
-CSSOM.CSSFontFaceRule.prototype.__defineGetter__("cssText", function() {
-	return "@font-face {" + this.style.cssText + "}";
+Object.defineProperty(CSSOM.CSSFontFaceRule.prototype, "cssText", {
+  get: function() {
+    return "@font-face {" + this.style.cssText + "}";
+  }
 });
 
 

--- a/lib/CSSImportRule.js
+++ b/lib/CSSImportRule.js
@@ -22,107 +22,109 @@ CSSOM.CSSImportRule = function CSSImportRule() {
 CSSOM.CSSImportRule.prototype = new CSSOM.CSSRule;
 CSSOM.CSSImportRule.prototype.constructor = CSSOM.CSSImportRule;
 CSSOM.CSSImportRule.prototype.type = 3;
-CSSOM.CSSImportRule.prototype.__defineGetter__("cssText", function() {
-	var mediaText = this.media.mediaText;
-	return "@import url(" + this.href + ")" + (mediaText ? " " + mediaText : "") + ";";
-});
 
-CSSOM.CSSImportRule.prototype.__defineSetter__("cssText", function(cssText) {
-	var i = 0;
+Object.defineProperty(CSSOM.CSSImportRule.prototype, "cssText", {
+  get: function() {
+    var mediaText = this.media.mediaText;
+    return "@import url(" + this.href + ")" + (mediaText ? " " + mediaText : "") + ";";
+  },
+  set: function(cssText) {
+    var i = 0;
 
-	/**
-	 * @import url(partial.css) screen, handheld;
-	 *        ||               |
-	 *        after-import     media
-	 *         |
-	 *         url
-	 */
-	var state = '';
+    /**
+     * @import url(partial.css) screen, handheld;
+     *        ||               |
+     *        after-import     media
+     *         |
+     *         url
+     */
+    var state = '';
 
-	var buffer = '';
-	var index;
-	var mediaText = '';
-	for (var character; character = cssText.charAt(i); i++) {
+    var buffer = '';
+    var index;
+    var mediaText = '';
+    for (var character; character = cssText.charAt(i); i++) {
 
-		switch (character) {
-			case ' ':
-			case '\t':
-			case '\r':
-			case '\n':
-			case '\f':
-				if (state === 'after-import') {
-					state = 'url';
-				} else {
-					buffer += character;
-				}
-				break;
+      switch (character) {
+        case ' ':
+        case '\t':
+        case '\r':
+        case '\n':
+        case '\f':
+          if (state === 'after-import') {
+            state = 'url';
+          } else {
+            buffer += character;
+          }
+          break;
 
-			case '@':
-				if (!state && cssText.indexOf('@import', i) === i) {
-					state = 'after-import';
-					i += 'import'.length;
-					buffer = '';
-				}
-				break;
+        case '@':
+          if (!state && cssText.indexOf('@import', i) === i) {
+            state = 'after-import';
+            i += 'import'.length;
+            buffer = '';
+          }
+          break;
 
-			case 'u':
-				if (state === 'url' && cssText.indexOf('url(', i) === i) {
-					index = cssText.indexOf(')', i + 1);
-					if (index === -1) {
-						throw i + ': ")" not found';
-					}
-					i += 'url('.length;
-					var url = cssText.slice(i, index);
-					if (url[0] === url[url.length - 1]) {
-						if (url[0] === '"' || url[0] === "'") {
-							url = url.slice(1, -1);
-						}
-					}
-					this.href = url;
-					i = index;
-					state = 'media';
-				}
-				break;
+        case 'u':
+          if (state === 'url' && cssText.indexOf('url(', i) === i) {
+            index = cssText.indexOf(')', i + 1);
+            if (index === -1) {
+              throw i + ': ")" not found';
+            }
+            i += 'url('.length;
+            var url = cssText.slice(i, index);
+            if (url[0] === url[url.length - 1]) {
+              if (url[0] === '"' || url[0] === "'") {
+                url = url.slice(1, -1);
+              }
+            }
+            this.href = url;
+            i = index;
+            state = 'media';
+          }
+          break;
 
-			case '"':
-				if (state === 'url') {
-					index = cssText.indexOf('"', i + 1);
-					if (!index) {
-						throw i + ": '\"' not found";
-					}
-					this.href = cssText.slice(i + 1, index);
-					i = index;
-					state = 'media';
-				}
-				break;
+        case '"':
+          if (state === 'url') {
+            index = cssText.indexOf('"', i + 1);
+            if (!index) {
+              throw i + ": '\"' not found";
+            }
+            this.href = cssText.slice(i + 1, index);
+            i = index;
+            state = 'media';
+          }
+          break;
 
-			case "'":
-				if (state === 'url') {
-					index = cssText.indexOf("'", i + 1);
-					if (!index) {
-						throw i + ': "\'" not found';
-					}
-					this.href = cssText.slice(i + 1, index);
-					i = index;
-					state = 'media';
-				}
-				break;
+        case "'":
+          if (state === 'url') {
+            index = cssText.indexOf("'", i + 1);
+            if (!index) {
+              throw i + ': "\'" not found';
+            }
+            this.href = cssText.slice(i + 1, index);
+            i = index;
+            state = 'media';
+          }
+          break;
 
-			case ';':
-				if (state === 'media') {
-					if (buffer) {
-						this.media.mediaText = buffer.trim();
-					}
-				}
-				break;
+        case ';':
+          if (state === 'media') {
+            if (buffer) {
+              this.media.mediaText = buffer.trim();
+            }
+          }
+          break;
 
-			default:
-				if (state === 'media') {
-					buffer += character;
-				}
-				break;
-		}
-	}
+        default:
+          if (state === 'media') {
+            buffer += character;
+          }
+          break;
+      }
+    }
+  }
 });
 
 

--- a/lib/CSSKeyframeRule.js
+++ b/lib/CSSKeyframeRule.js
@@ -25,8 +25,10 @@ CSSOM.CSSKeyframeRule.prototype.type = 9;
 //CSSOM.CSSKeyframeRule.prototype.deleteRule = CSSStyleSheet.prototype.deleteRule;
 
 // http://www.opensource.apple.com/source/WebCore/WebCore-955.66.1/css/WebKitCSSKeyframeRule.cpp
-CSSOM.CSSKeyframeRule.prototype.__defineGetter__("cssText", function() {
-	return this.keyText + " {" + this.style.cssText + "} ";
+Object.defineProperty(CSSOM.CSSKeyframeRule.prototype, "cssText", {
+  get: function() {
+    return this.keyText + " {" + this.style.cssText + "} ";
+  }
 });
 
 

--- a/lib/CSSKeyframesRule.js
+++ b/lib/CSSKeyframesRule.js
@@ -23,12 +23,14 @@ CSSOM.CSSKeyframesRule.prototype.type = 8;
 //CSSOM.CSSKeyframesRule.prototype.deleteRule = CSSStyleSheet.prototype.deleteRule;
 
 // http://www.opensource.apple.com/source/WebCore/WebCore-955.66.1/css/WebKitCSSKeyframesRule.cpp
-CSSOM.CSSKeyframesRule.prototype.__defineGetter__("cssText", function() {
-	var cssTexts = [];
-	for (var i=0, length=this.cssRules.length; i < length; i++) {
-		cssTexts.push("  " + this.cssRules[i].cssText);
-	}
-	return "@" + (this._vendorPrefix || '') + "keyframes " + this.name + " { \n" + cssTexts.join("\n") + "\n}";
+Object.defineProperty(CSSOM.CSSKeyframesRule.prototype, "cssText", {
+  get: function() {
+    var cssTexts = [];
+    for (var i=0, length=this.cssRules.length; i < length; i++) {
+      cssTexts.push("  " + this.cssRules[i].cssText);
+    }
+    return "@" + (this._vendorPrefix || '') + "keyframes " + this.name + " { \n" + cssTexts.join("\n") + "\n}";
+  }
 });
 
 

--- a/lib/CSSMediaRule.js
+++ b/lib/CSSMediaRule.js
@@ -25,12 +25,14 @@ CSSOM.CSSMediaRule.prototype.type = 4;
 //CSSOM.CSSMediaRule.prototype.deleteRule = CSSStyleSheet.prototype.deleteRule;
 
 // http://opensource.apple.com/source/WebCore/WebCore-658.28/css/CSSMediaRule.cpp
-CSSOM.CSSMediaRule.prototype.__defineGetter__("cssText", function() {
-	var cssTexts = [];
-	for (var i=0, length=this.cssRules.length; i < length; i++) {
-		cssTexts.push(this.cssRules[i].cssText);
-	}
-	return "@media " + this.media.mediaText + " {" + cssTexts.join("") + "}";
+Object.defineProperty(CSSOM.CSSMediaRule.prototype, "cssText", {
+  get: function() {
+    var cssTexts = [];
+    for (var i=0, length=this.cssRules.length; i < length; i++) {
+      cssTexts.push(this.cssRules[i].cssText);
+    }
+    return "@media " + this.media.mediaText + " {" + cssTexts.join("") + "}";
+  }
 });
 
 

--- a/lib/CSSStyleRule.js
+++ b/lib/CSSStyleRule.js
@@ -22,20 +22,21 @@ CSSOM.CSSStyleRule.prototype = new CSSOM.CSSRule;
 CSSOM.CSSStyleRule.prototype.constructor = CSSOM.CSSStyleRule;
 CSSOM.CSSStyleRule.prototype.type = 1;
 
-CSSOM.CSSStyleRule.prototype.__defineGetter__("cssText", function() {
-	var text;
-	if (this.selectorText) {
-		text = this.selectorText + " {" + this.style.cssText + "}";
-	} else {
-		text = "";
+Object.defineProperty(CSSOM.CSSStyleRule.prototype, "cssText", {
+	get: function() {
+		var text;
+		if (this.selectorText) {
+			text = this.selectorText + " {" + this.style.cssText + "}";
+		} else {
+			text = "";
+		}
+		return text;
+	},
+	set: function(cssText) {
+		var rule = CSSOM.CSSStyleRule.parse(cssText);
+		this.style = rule.style;
+		this.selectorText = rule.selectorText;
 	}
-	return text;
-});
-
-CSSOM.CSSStyleRule.prototype.__defineSetter__("cssText", function(cssText) {
-	var rule = CSSOM.CSSStyleRule.parse(cssText);
-	this.style = rule.style;
-	this.selectorText = rule.selectorText;
 });
 
 

--- a/lib/CSSValueExpression.js
+++ b/lib/CSSValueExpression.js
@@ -253,7 +253,7 @@ instanceof /a/
 
 */
 CSSOM.CSSValueExpression.prototype._parseJSRexExp = function(token, idx) {
-	var before = token.substring(0, idx).trimRight(),
+	var before = token.substring(0, idx).replace(/\s+$/, ""),
 			legalRegx = [
 				/^$/,
 				/\($/,


### PR DESCRIPTION
Replaced **define[G|S]etter** with Object.defineProperty for IE9 and later. Since some existing code (e.g, CSSStyleDeclaration.js) only supports IE9 and later, I think it is reasonable to replacing them without backward compatibility.

Also, replaced String.trimRight with String.replace(/\s+$/,"") because trimRight
is not ECMAScript5 function and IE does not support it.
