### PR TITLE
Fix parse error in PhantomJS 1.9.2 and possibly some versions of WebKit

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -123,7 +123,7 @@ CSSOM.CSSStyleDeclaration.prototype = {
 		return properties.join(" ");
 	},
 
-	set cssText(cssText){
+	set cssText(text){
 		var i, name;
 		for (i = this.length; i--;) {
 			name = this[i];
@@ -132,7 +132,7 @@ CSSOM.CSSStyleDeclaration.prototype = {
 		Array.prototype.splice.call(this, 0, this.length);
 		this._importants = {};
 
-		var dummyRule = CSSOM.parse('#bogus{' + cssText + '}').cssRules[0].style;
+		var dummyRule = CSSOM.parse('#bogus{' + text + '}').cssRules[0].style;
 		var length = dummyRule.length;
 		for (i = 0; i < length; ++i) {
 			name = dummyRule[i];


### PR DESCRIPTION
This small change makes PhantomJS parse CSSOM. Fixes #52
