### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
 	"devDependencies": {
 		"jake": "~0.7.3"
 	},
-	"license": {
-		"type": "MIT",
-		"url": "http://creativecommons.org/licenses/MIT/"
-	},
+	"license": "MIT",
 	"scripts": {
 		"prepublish": "jake lib/index.js"
 	}


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/