### PR TITLE
Added fix for handling of spaces within parenthesis in values.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -24,7 +24,7 @@ CSSOM.parse = function parse(token) {
 
 	var index;
 	var buffer = "";
-	var valueParenthesisDepth=0;
+	var valueParenthesisDepth = 0;
 
 	var SIGNIFICANT_WHITESPACE = {
 		"selector": true,
@@ -255,24 +255,24 @@ CSSOM.parse = function parse(token) {
 			if (state === 'value') {
 				// ie css expression mode
 				if (buffer.trim() === 'expression') {
-          var info = (new CSSOM.CSSValueExpression(token, i)).parse();
+					var info = (new CSSOM.CSSValueExpression(token, i)).parse();
 
-          if (info.error) {
-            parseError(info.error);
-          } else {
-            buffer += info.expression;
-            i = info.idx;
-          }
-        } else if (state === 'value-parenthesis') {
-          valueParenthesisDepth++;
-          buffer += character;
+					if (info.error) {
+						parseError(info.error);
+					} else {
+						buffer += info.expression;
+						i = info.idx;
+					}
 				} else {
 					state = 'value-parenthesis';
-          //always ensure this is reset to 1 on transition
+					//always ensure this is reset to 1 on transition
 					//from value to value-parenthesis
-          valueParenthesisDepth=1;
+					valueParenthesisDepth = 1;
 					buffer += character;
 				}
+			} else if (state === 'value-parenthesis') {
+				valueParenthesisDepth++;
+				buffer += character;
 			} else {
 				buffer += character;
 			}
@@ -281,7 +281,7 @@ CSSOM.parse = function parse(token) {
 		case ")":
 			if (state === 'value-parenthesis') {
 				valueParenthesisDepth--;
-				if(valueParenthesisDepth === 0) state = 'value';
+				if (valueParenthesisDepth === 0) state = 'value';
 			}
 			buffer += character;
 			break;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -24,10 +24,12 @@ CSSOM.parse = function parse(token) {
 
 	var index;
 	var buffer = "";
+	var valueParenthesisDepth=0;
 
 	var SIGNIFICANT_WHITESPACE = {
 		"selector": true,
 		"value": true,
+		"value-parenthesis": true,
 		"atRule": true,
 		"importRule-begin": true,
 		"importRule": true,
@@ -253,16 +255,22 @@ CSSOM.parse = function parse(token) {
 			if (state === 'value') {
 				// ie css expression mode
 				if (buffer.trim() === 'expression') {
-					var info = (new CSSOM.CSSValueExpression(token, i)).parse();
+          var info = (new CSSOM.CSSValueExpression(token, i)).parse();
 
-					if (info.error) {
-						parseError(info.error);
-					} else {
-						buffer += info.expression;
-						i = info.idx;
-					}
+          if (info.error) {
+            parseError(info.error);
+          } else {
+            buffer += info.expression;
+            i = info.idx;
+          }
+        } else if (state === 'value-parenthesis') {
+          valueParenthesisDepth++;
+          buffer += character;
 				} else {
 					state = 'value-parenthesis';
+          //always ensure this is reset to 1 on transition
+					//from value to value-parenthesis
+          valueParenthesisDepth=1;
 					buffer += character;
 				}
 			} else {
@@ -272,7 +280,8 @@ CSSOM.parse = function parse(token) {
 
 		case ")":
 			if (state === 'value-parenthesis') {
-				state = 'value';
+				valueParenthesisDepth--;
+				if(valueParenthesisDepth === 0) state = 'value';
 			}
 			buffer += character;
 			break;

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -446,6 +446,28 @@ var TESTS = [
 		})()
 	},
 	{
+		input: ".calc{width: calc(100% - 15px);}",
+		result: (function() {
+			var result = {
+				cssRules: [
+					{
+						selectorText: '.calc',
+						parentRule: null,
+						style: {
+							0: 'width',
+							width: 'calc(100% - 15px)',
+							length: 1
+						}
+					}
+				],
+				parentStyleSheet: null
+			};
+			result.cssRules[0].parentStyleSheet = result;
+			result.cssRules[0].style.parentRule = result.cssRules[0];
+			return result;
+		})()
+	},
+	{
 		input: ".gradient{background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);}",
 		result: (function() {
 			var result = {

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -446,6 +446,28 @@ var TESTS = [
 		})()
 	},
 	{
+		input: ".gradient{background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);}",
+		result: (function() {
+			var result = {
+				cssRules: [
+					{
+						selectorText: '.gradient',
+						parentRule: null,
+						style: {
+							0: 'background-image',
+							"background-image": 'linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%)',
+							length: 1
+						}
+					}
+				],
+				parentStyleSheet: null
+			};
+			result.cssRules[0].parentStyleSheet = result;
+			result.cssRules[0].style.parentRule = result.cssRules[0];
+			return result;
+		})()
+	},
+	{
 		input: "@media handheld, only screen and (max-device-width: 480px) {body{max-width:480px}}",
 		result: (function() {
 			var result = {


### PR DESCRIPTION
Also added handling of nested parenthesis in a value so that it doesn't leave the value-parenthesis state until all open parenthesis are matched with a close.

Added  a test for the case I ran across this problem where I had a linear-gradient with an RGBA value for the second transition point, but transparent for the first.  The space was dropped after the transparent, but not the rgba value because the closing paren of the RGBA value transitioned back into the value state from value-parenthesis.

This should resolve #86 also - I just added a test case for that to my PR.