### PR TITLE
Expose CSSOM.parse to CSSGroupingRule

### DIFF
--- a/lib/CSSGroupingRule.js
+++ b/lib/CSSGroupingRule.js
@@ -1,6 +1,7 @@
 //.CommonJS
 var CSSOM = {
-	CSSRule: require("./CSSRule").CSSRule
+	CSSRule: require("./CSSRule").CSSRule,
+	parse: require('./parse').parse
 };
 ///CommonJS
 


### PR DESCRIPTION
Currently CSSGroupingRule is calling CSSOM.parse but `parse` wasn't included which leads to a syntax error.
This PR fixes that

Line which is currently calling `CSSOM.parse`: https://github.com/NV/CSSOM/blob/a469aae2f92e454e669aec821781626924f98d17/lib/CSSGroupingRule.js#L41