### PR TITLE
Expose `parse` to `CSSGroupingRule`

### DIFF
--- a/lib/CSSGroupingRule.js
+++ b/lib/CSSGroupingRule.js
@@ -65,4 +65,5 @@ CSSOM.CSSGroupingRule.prototype.constructor = CSSOM.CSSGroupingRule;
 
 //.CommonJS
 exports.CSSGroupingRule = CSSOM.CSSGroupingRule;
+CSSOM.parse = require('./parse').parse; // Cannot be included sooner due to the mutual dependency between parse.js and CSSStyleDeclaration.js
 ///CommonJS


### PR DESCRIPTION
`CSSGroupingRule.insertRule` requires `parse`. Previously:

    $ pwd
    /path/to/CSSOM
    $ node
    Welcome to Node.js v18.1.0.
    Type ".help" for more information.
    > const CSSOM = require('./lib');
    undefined
    > const rule = new CSSOM.CSSGroupingRule();
    undefined
    > rule.insertRule('#a{}', 0);
    Uncaught TypeError: CSSOM.parse is not a function
        at CSSGroupingRule.insertRule (/path/to/CSSOM/lib/CSSGroupingRule.js:41:22)

Now:

    > rule.insertRule('#a{}', 0);
    0